### PR TITLE
Update for CAP - Platform Outputs

### DIFF
--- a/17-data_integrity_policy.md
+++ b/17-data_integrity_policy.md
@@ -52,6 +52,12 @@ Software patches and updates will be applied to all systems in a timely manner. 
 1. System, network, and server security is managed and maintained by the Security Officer in conjunction with the DevOps team.
 2. Up to date system lists and architecture diagrams are kept for all production environments.
 3. Access to Production Systems is controlled using centralized tools and two-factor authentication.
+4. The process for granting access to the Production Systems is owned by the Information Security team and is outlined below. Any disruption in the described process will result in a delay or rejection of the request to the Production System.
+  1. The requesting user will submit a request utilizing a Slack workflow 
+  2. The requesting user's Supervisor will approve the stated business need
+  3. The HR team will verify the requesting user has completed their required HIPAA training
+  4. The Information Security Team will verify the disk encryption, Meraki and Crowdstrike management of the device and provide access to the designated device and user following a security training pertaining specifically to the Production System.
+
 
 ## 17.8 Production Data Security
 
@@ -83,7 +89,7 @@ Software patches and updates will be applied to all systems in a timely manner. 
 1. Stronger controls are in place to protect certain electronic messages, such as E-Mail, ensuring they are protected end-to-end.
 1. E-Mail communications use opportunistic TLS by default, ensuring that all transmissions are sent over an encrypted channel providing they can be accepted by the recipient. Data containing PHI should not be transmitted over E-Mail.
  
-## 18.0 Data De-Identification
+## 17.10 Data De-Identification
 
 Luma follows the U.S. Department of Health and Human Services Safe Harbor guidelines for de-indentification of data containing PHI to ensure we remain in compliance with HIPAA.
 


### PR DESCRIPTION
https://app.clickup.com/t/2zh4ecr

CAP: Luma will update our Policy and Procedures to specify that covered information outputs are only sent to authorized locations, specifically Luma Employees, on a Luma provided and managed device with appropriate security controls applied, with a valid logon account over a VPN connection. 


From HITRUST: Outputs from the platform being sent to authorized terminals/locations are not addressed.

# Pull Request Template

Filling this template is mandatory. PRs will be immediately closed by maintainers if this template is not filled.

## Description

Please include a summary of the change and provide links to any relevant ClickUp tickets. Also list any dependencies that are required for this change.

Summary

ClickUp Ticket(s)

## How Has This Been Tested?
 
- [ ] Manual Testing
- [ ] Automated Testing
- [ ] Both Manual and Automated Testing Performed

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

## Final Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have tested my code to prove my fix is effective or that my feature works
- [ ] I have commented my code in areas where it's hard to make the code speak for itself
- [ ] My changes breaks no tests
- [ ] I have reviewed and understand the Root Cause Analysis (RCA) of recent incidents
- [ ] POST DEPLOY - I have verified that this change was successful or initiated a backout 
